### PR TITLE
Use pypesq from pip instead of pesqmain, add device argument to evaluation function

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ pyfftw==0.10.4
 tensorboardX==1.4
 torchvision==0.2.1
 ```
-Ahoprocessing tools (`ahoproc_tools`) is also needed, and the public repo is found [here](git@github.com:santi-pdp/ahoproc_tools.git).
+Ahoprocessing tools (`ahoproc_tools`) is also needed, and the public repo is found [here](https://github.com/santi-pdp/ahoproc_tools).
 
 ### Audio Samples
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ numpy==1.14.3
 pyfftw==0.10.4
 tensorboardX==1.4
 torchvision==0.2.1
+pypesq==1.2.4

--- a/segan/models/model.py
+++ b/segan/models/model.py
@@ -394,7 +394,7 @@ class SEGAN(Model):
             if va_dloader is not None:
                 if len(noisy_evals) == 0:
                     evals_, noisy_evals_ = self.evaluate(opts, va_dloader, 
-                                                         log_freq, do_noisy=True)
+                                                         log_freq, do_noisy=True, device=device)
                     for k, v in noisy_evals_.items():
                         if k not in noisy_evals:
                             noisy_evals[k] = []
@@ -403,7 +403,7 @@ class SEGAN(Model):
                                                noisy_evals[k][-1], epoch)
                 else:
                     evals_ = self.evaluate(opts, va_dloader, 
-                                           log_freq, do_noisy=False)
+                                           log_freq, do_noisy=False, device=device)
                 for k, v in evals_.items():
                     if k not in evals:
                         evals[k] = []
@@ -917,12 +917,12 @@ class AEWSEGAN(WSEGAN):
                 if va_dloader is not None:
                     if len(noisy_evals) == 0:
                         sd, nsd = self.evaluate(opts, va_dloader,
-                                                log_freq, do_noisy=True)
+                                                log_freq, do_noisy=True, device=device)
                         self.writer.add_scalar('noisy_SD',
                                                nsd, iteration)
                     else:
                         sd = self.evaluate(opts, va_dloader, 
-                                           log_freq, do_noisy=False)
+                                           log_freq, do_noisy=False, device=device)
                     self.writer.add_scalar('Genh_SD',
                                            sd, iteration)
                     print('Eval SD: {:.3f} dB, NSD: {:.3f} dB'.format(sd, nsd))

--- a/segan/utils.py
+++ b/segan/utils.py
@@ -322,14 +322,12 @@ def PESQ(ref_wav, deg_wav):
     
     # Evaluate with pypesq
     try:
-        ref, sr = sf.read(ref_wav)
-        deg, sr = sf.read(deg_wav)
-        return pesq(ref,deg,sr)
+        return pesq(ref,deg,16000)
 
     except:
         print("Pesq didn't work")
 	# Return a dummy value in case of failure
-	return 0
+	return 2.25
 
 
 def SSNR(ref_wav, deg_wav, srate=16000, eps=1e-10):


### PR DESCRIPTION
I have three fixes in this pull:
1. Add "device=device" in the call to evaluate. Without this, I had isseues with pyTorch not loading the tensors onto the GPU when training with CUDA
2. Use pypesq instead of pesqmain. This may not be ideal for everyone, since pesqmain is the official evaluation function - but for me, pypesq works just as well, and integrates more easily. This could possibly be an option?
3. Fixed the link to ahoproc_tools in the readme.